### PR TITLE
fix dials saving incorrectly

### DIFF
--- a/src/widgets/DoubleDialWidget.cpp
+++ b/src/widgets/DoubleDialWidget.cpp
@@ -5,6 +5,7 @@
 
 DoubleDialWidget::DoubleDialWidget(const QString &title, const double &defaultValue, const QString &topic) : DoubleDisplayWidget(title, defaultValue, topic) {
     m_dial = new QDial(this);
+    m_type = WidgetTypes::DoubleDial;
 
     m_fakeValue = defaultValue * 100;
 

--- a/src/widgets/IntegerDialWidget.cpp
+++ b/src/widgets/IntegerDialWidget.cpp
@@ -5,6 +5,7 @@
 
 IntegerDialWidget::IntegerDialWidget(const QString &title, const int &defaultValue, const QString &topic) : IntegerDisplayWidget(title, defaultValue, topic) {
     m_dial = new QDial(this);
+    m_type = WidgetTypes::IntegerDial;
 
     m_dial->setMinimum(0);
     m_dial->setMaximum(36000);


### PR DESCRIPTION
saved with the display widget types, not their own unique types, resulting in them loading in as the display widgets