### PR TITLE
Fix CameraView & StringChooser reconnect behavior

### DIFF
--- a/lib/include/MainWindow.h
+++ b/lib/include/MainWindow.h
@@ -42,6 +42,7 @@ public slots:
     // Internal Stuff
     void forceUpdateTab(int idx);
     void moveTab(int from, int to);
+    void setConnected(bool connected);
 
     // Preferences
     void preferences();

--- a/lib/src/MainWindow.cpp
+++ b/lib/src/MainWindow.cpp
@@ -165,6 +165,14 @@ void MainWindow::moveTab(int from, int to) {
     m_tabs.move(from, to);
 }
 
+void MainWindow::setConnected(bool connected) {
+    for (TabWidget *tab : m_tabs) {
+        for (BaseWidget *widget : tab->widgets()) {
+            widget->setConnected(connected);
+        }
+    }
+}
+
 // Preferences
 void MainWindow::preferences() {
     PreferencesDialog *dialog = new PreferencesDialog(this);

--- a/lib/src/stores/TopicStore.cpp
+++ b/lib/src/stores/TopicStore.cpp
@@ -126,7 +126,7 @@ nt::NetworkTableEntry *TopicStore::subscribe(std::string ntTopic, BaseWidget *su
             }
         };
 
-        NT_Listener handle = Globals::inst.AddListener(Globals::inst.GetEntry(ntTopic), nt::EventFlags::kValueAll | nt::EventFlags::kPublish | nt::EventFlags::kUnpublish, updateWidget);
+        NT_Listener handle = Globals::inst.AddListener(Globals::inst.GetEntry(ntTopic), nt::EventFlags::kValueAll, updateWidget);
 
         listener.listenerHandle = handle;
         listener.callback = updateWidget;

--- a/lib/src/stores/TopicStore.cpp
+++ b/lib/src/stores/TopicStore.cpp
@@ -88,22 +88,6 @@ nt::NetworkTableEntry *TopicStore::subscribe(std::string ntTopic, BaseWidget *su
                 return;
             }
 
-            if (event.Is(nt::EventFlags::kUnpublish)) {
-                QMetaObject::invokeMethod(subscriber, [subscriber] {
-                    subscriber->setConnected(false);
-                });
-
-                return;
-            }
-
-            if (event.Is(nt::EventFlags::kPublish)) {
-                QMetaObject::invokeMethod(subscriber, [subscriber] {
-                    subscriber->setConnected(true);
-                });
-
-                return;
-            }
-
             nt::Value value;
             if (!event.Is(nt::EventFlags::kValueAll)) {
                 value = entry->GetValue();

--- a/lib/src/widgets/CameraViewWidget.cpp
+++ b/lib/src/widgets/CameraViewWidget.cpp
@@ -40,7 +40,6 @@ void CameraViewWidget::forceUpdate() {
 }
 
 void CameraViewWidget::setConnected(bool connected) {
-    qDebug() << connected;
     if (connected) setUrl(m_url);
     else m_player->stop();
 }

--- a/lib/src/widgets/CameraViewWidget.cpp
+++ b/lib/src/widgets/CameraViewWidget.cpp
@@ -1,18 +1,16 @@
  #include "widgets/CameraViewWidget.h"
 
 #include <QMenu>
+#include <QThread>
 
 CameraViewWidget::CameraViewWidget(const QString &title, const QUrl &url) : BaseWidget(WidgetTypes::CameraView, title, "", true)
 {
     m_videoWidget = new QVideoWidget(this);
 
     m_player = new QMediaPlayer(this);
-    m_url = url;
-
-    m_player->setSource(url);
     m_player->setVideoOutput(m_videoWidget);
 
-    m_player->play();
+    setUrl(url);
 
     m_layout->addWidget(m_videoWidget, 1, 0, 4, 1);
     setReady(true);
@@ -29,17 +27,22 @@ QUrl CameraViewWidget::url() {
 void CameraViewWidget::setUrl(const QUrl &url) {
     m_url = url;
 
+    m_player->stop();
+
+    QThread::msleep(100);
+
     m_player->setSource(url);
     m_player->play();
 }
 
 void CameraViewWidget::forceUpdate() {
-    // setUrl(m_url);
     m_player->play();
 }
 
 void CameraViewWidget::setConnected(bool connected) {
+    qDebug() << connected;
     if (connected) setUrl(m_url);
+    else m_player->stop();
 }
 
 QMenu *CameraViewWidget::constructContextMenu(WidgetData data) {

--- a/lib/src/widgets/StringChooserWidget.cpp
+++ b/lib/src/widgets/StringChooserWidget.cpp
@@ -41,6 +41,7 @@ void StringChooserWidget::setTopic(const QString &topic) {
 
 void StringChooserWidget::setValue(const nt::Value &value, QString label, bool force) {
     if (force) {
+        qDebug() << "Bro";
         QMap<std::string, QString> map{};
         map.insert("/active", "Active");
         map.insert("/options", "Choices");
@@ -54,19 +55,9 @@ void StringChooserWidget::setValue(const nt::Value &value, QString label, bool f
         return;
     }
 
-    // only update active if we're NOT reconnecting,
-    // to send the current choice to NT.
-
     else {
         if (label == "Active") {
-            if (!m_connected) {
-                return;
-            }
-
             if (!m_readyToUpdate) {
-                QTimer::singleShot(200, this, [this] {
-                    updateSelected(m_lastSelected);
-                });
                 m_readyToUpdate = true;
                 return;
             }
@@ -91,8 +82,9 @@ void StringChooserWidget::setValue(const nt::Value &value, QString label, bool f
             for (const std::string &choice : choices) {
                 qchoices << QString::fromStdString(choice);
             }
+
+            qchoices.sort();
             m_chooser->addItems(qchoices);
-            // m_chooser->setCurrentText(m_value);
 
             updateSelected(selected);
         }
@@ -137,10 +129,11 @@ void StringChooserWidget::updateSelected(const QString text) {
 
 void StringChooserWidget::setConnected(bool connected) {
     BaseWidget::setConnected(connected);
-
-    m_readyToUpdate = false;
+    m_connected = connected;
 
     if (connected) {
+        m_readyToUpdate = false;
+
         updateSelected(m_lastSelected);
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -67,6 +67,8 @@ int main(int argc, char **argv) {
                          QString::fromStdString(Globals::server.server),
                          QString(connected ? "" : "Not ") + "Connected")
                 );
+
+            window->setConnected(connected);
         });
     });
 


### PR DESCRIPTION
- Reconnect button & general server reconnection properly reset the CameraView widget.
- CameraView no longer hangs when waiting for connection
- Fixed choices not updating for string chooser
- Really, really fixed string chooser reconnect behavior.
